### PR TITLE
Update BadNets test script to use CIFAR10 dataset

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -4,7 +4,7 @@
 
 export PYTHONPATH="/home/lab/SCALE-UP:$PYTHONPATH"
 cd /home/lab/SCALE-UP
-python test_BadNets.py
+python test_BadNets_cifar10.py
 python torch_model_wrapper.py --model_type=benign
 python dataloader2tensor_CIFAR10.py
 python torch_model_wrapper.py --model_type=backdoor


### PR DESCRIPTION
This pull request updates the BadNets test script to use the CIFAR10 dataset instead of the previous dataset. The changes include updating the script name to reflect the new dataset and modifying the relevant lines in the script to use the new dataset. This update ensures that the BadNets test script is using the correct dataset for testing.