### PR TITLE
Refactor file paths and update model checkpoint

### DIFF
--- a/dataloader2tensor_CIFAR10.py
+++ b/dataloader2tensor_CIFAR10.py
@@ -48,7 +48,7 @@ for batch_id, batch in enumerate(poisoned_test_dataloader):
     if (batch_id + 1) % 100 == 0:
         print((batch_id + 1)/100)
 
-torch.save(poisoned_test_samples, 'poisoned_test_samples_BadNets.pth')
+torch.save(poisoned_test_samples, 'badnet/poisoned_test_samples_BadNets.pth')
 #torch.save(poisoned_test_samples, 'poisoned_test_samples_WaNet_VGG.pth')
 #torch.save(poisoned_test_samples, 'poisoned_test_samples_ISSBA_VGG.pth')
 #torch.save(poisoned_test_samples, 'poisoned_test_samples_BadNets_VGG.pth')

--- a/run.sh
+++ b/run.sh
@@ -5,6 +5,10 @@
 export PYTHONPATH="/home/lab/SCALE-UP:$PYTHONPATH"
 cd /home/lab/SCALE-UP
 python test_BadNets_cifar10.py
+
+newest_folder=$(ls -dt train_poisoned_CIFAR10_*/ | head -1)
+cp "${newest_folder}"ckpt_epoch_200.pth badnet/
+
 python torch_model_wrapper.py --model_type=benign
 python dataloader2tensor_CIFAR10.py
 python torch_model_wrapper.py --model_type=backdoor

--- a/torch_model_wrapper.py
+++ b/torch_model_wrapper.py
@@ -23,12 +23,12 @@ deterministic = True
 torch.manual_seed(global_seed)
 CUDA_VISIBLE_DEVICES = args.gpu_id
 
-dataloader_root_dir = "benign_test_samples.pth" if args.model_type == "benign" else 'poisoned_test_samples_BadNets.pth'
+dataloader_root_dir = "badnet/benign_test_samples.pth" if args.model_type == "benign" else 'badnet/poisoned_test_samples_BadNets.pth'
 
 device = torch.device("cuda:0")
 resnet18 = core.models.ResNet(18)
 model = resnet18
-model.load_state_dict(torch.load("experiments/train_poisoned_CIFAR10_2023-11-10_15:43:12/ckpt_epoch_2.pth", map_location=device))
+model.load_state_dict(torch.load("badnet/ckpt_epoch_200.pth", map_location=device))
 
 model.to(device)
 model.eval()


### PR DESCRIPTION
This pull request refactors file paths and updates the model checkpoint for the BadNets project. The `poisoned_test_samples_BadNets.pth` file is moved to the `badnet` folder, and the `ckpt_epoch_200.pth` file is copied to the `badnet` folder. The `test_BadNets_cifar10.py` script is updated to use the new file paths.

No issues are fixed in this pull request.